### PR TITLE
VSCode でコンテナ立ち上げ時に、コンテナ内で "yarn install" を自動実行する

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,6 +3,7 @@
 	"dockerComposeFile": "../docker-compose.yml",
 	"service": "app",
 	"workspaceFolder": "/app",
+	"postCreateCommand": "yarn install",
 	"extensions": [
 		"esbenp.prettier-vscode",
 		"dbaeumer.vscode-eslint",


### PR DESCRIPTION
## 🔨 Details of Changes
<!-- 変更内容について記載する -->
- `.devcontainer/devcontainer.json` に `postCreateCommand` の設定を追加
- `$ git clone` 後、`$ make i` なしで Remote Container を立ち上げられるようになる
- Windows 環境未確認

## ✅ Resolved Issues
<!-- 解決する Issues を記載する -->
- close #25 

## Reference
- [postCreateCommand](https://code.visualstudio.com/docs/remote/devcontainerjson-reference#:~:text=A%20command%20string%20or%20list,sh.%20Not%20set%20by%20default.)